### PR TITLE
Update script.js

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -31,7 +31,7 @@
 				$imgAlt = $img.attr('data-alt'),
 				$imgExt = $imgAlt.split('.');
 				
-		if($imgExt[1] === 'gif') {
+		if($imgExt[$imgExt.length-1] === 'gif') {
 			$img.attr('src', $img.data('alt')).attr('data-alt', $imgSrc);
 		} else {
 			$img.attr('src', $imgAlt).attr('data-alt', $img.data('alt'));


### PR DESCRIPTION
Image src url  can have many "." , example of such url is www.example.dev/images/example.gif
in that case $imgExt[3] === 'gif'. So instead of using $imgExt[1] we can use $imgExt[$imgExt.length-1] and it will always be 'gif'.